### PR TITLE
Separate positive prompt G and L if ' . ' present

### DIFF
--- a/sdxl_prompt_styler.py
+++ b/sdxl_prompt_styler.py
@@ -207,11 +207,9 @@ class SDXLPromptStyler:
         
         return {
             "required": {
-                "text_positive_g": ("STRING", {"default": "", "multiline": True}),
-                "text_positive_l": ("STRING", {"default": "", "multiline": True}),
+                "text_positive": ("STRING", {"default": "", "multiline": True}),
                 "text_negative": ("STRING", {"default": "", "multiline": True}),
                 "style": ((styles), ),
-                "split_style": (["L only", "G only", "Both"], {"default":"L only"}),
                 "log_prompt": (["No", "Yes"], {"default":"No"}),
             },
         }
@@ -221,7 +219,7 @@ class SDXLPromptStyler:
     FUNCTION = 'prompt_styler'
     CATEGORY = 'utils'
 
-    def prompt_styler(self, text_positive_g, text_positive_l, text_negative, style, split_style, log_prompt):
+    def prompt_styler(self, text_positive, text_negative, style, log_prompt):
         # Process and combine prompts in templates
         # The function replaces the positive prompt placeholder in the template,
         # and combines the negative prompt with the template's negative prompt, if they exist.
@@ -231,8 +229,7 @@ class SDXLPromptStyler:
         # print the style, positive and negative text, and positive and negative prompts to the console
         if log_prompt == "Yes":
             print(f"style: {style}")
-            print(f"text_positive_g: {text_positive_g}")
-            print(f"text_positive_l: {text_positive_l}")
+            print(f"text_positive: {text_positive}")
             print(f"text_negative: {text_negative}")
             print(f"text_positive_styled: {text_positive_styled}")
             print(f"text_negative_styled: {text_negative_styled}")


### PR DESCRIPTION
Trying a modification of the behavior of the style parser. After some testing it seems that all the positive template after ` . ` should be used as positive prompt L instead of simply pasted at the end of the positive prompt G.

Here is a quick example with the `sai-pixel art` style with the default behavior :

 - prompt G : pixel-art full body portrait of two girls,ginger hair, starry sky background, medieval village . low-res, blocky, pixel art style, 8-bit graphics
 - negative prompt : sloppy, messy, blurry, noisy, highly detailed, ultra textured, photo, realistic

![ComfyUI_00036_](https://github.com/twri/sdxl_prompt_styler/assets/15424198/da0c9591-2763-4e60-89cb-e5e060f853bd)

And here is with the proposed fix : 
 - prompt G : pixel-art full body portrait of two girls,ginger hair, starry sky background, medieval village
 - prompt L : low-res, blocky, pixel art style, 8-bit graphics
 - negative prompt : sloppy, messy, blurry, noisy, highly detailed, ultra textured, photo, realistic

![ComfyUI_00035_](https://github.com/twri/sdxl_prompt_styler/assets/15424198/bd5cef9e-49fe-4620-9046-baeb9926863b)

As you can see the style is much more effective with the second method. It works for all the templates, it seems that Stability AI expected the part after ` . ` to be put as supporting terms.

NB : If you put the supporting term in the L **and** G prompt, the effect is even stonger, but I think somewhat too strong even. It could be set as an option :  

 - prompt G : pixel-art full body portrait of two girls,ginger hair, starry sky background, medieval village . low-res, blocky, pixel art style, 8-bit graphics
 - prompt L : low-res, blocky, pixel art style, 8-bit graphics
 - negative prompt : sloppy, messy, blurry, noisy, highly detailed, ultra textured, photo, realistic

![ComfyUI_00040_](https://github.com/twri/sdxl_prompt_styler/assets/15424198/3f831e87-9811-4eee-9db4-2c107dbf41f9)
